### PR TITLE
change mkdocs-material to non-insiders

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -233,7 +233,7 @@ nav:
   # - Community: "https://uxdiscuss.entropy-lab.io"
 
 plugins:
-  - meta
+  # - meta
   - search
   - table-reader:
       data_path: "docs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "QM's unified documentation and resources"
+name = "QM unified documentation and resources"
 version = "0.1.0"
 description = ""
 authors = ["Nikola Sibalic <nikola@quantum-machines.co>"]
@@ -20,7 +20,7 @@ mkdocs-glightbox = "^0.3.0"
 mkdocs-exclude = "^1.0.2"
 qm-qua = {path = "./docs/docs/qm-qua-sdk", develop=true}
 mkdocs-macros-plugin = "^0.7.0"
-mkdocs-material = {git = "https://github.com/entropy-lab/mkdocs-material-insiders.git"}
+mkdocs-material = "^9.5.17"
 pip = "^22.3.1"
 install = "^1.3.5"
 mkdocs-git-committers-plugin-2 = "^1.1.1"


### PR DESCRIPTION
This PR changes the required package from mkdocs-materials-insiders back to mkdocs-materials. The reason is that we are currently not using any features of mkdocs-materials-insiders and it has caused environment issues.

If we need additional features later on, we can always switch back to mkdocs-materials-insiders.

I also only verified locally that the documentation runs with this PR, it should be tested elsewhere as well.  
It would also be good if someone could double check that we're not using any additional insiders plugins

I also made a slight change to `tool.poetry.name`, removing the apostrophe. The reason is that my poetry virtual environment couldn't be selected with an apostrophe in the title. Feel free to revert this change.